### PR TITLE
Fix: Resolve registration errors and improve addon stability

### DIFF
--- a/MoText_addon/__init__.py
+++ b/MoText_addon/__init__.py
@@ -54,48 +54,55 @@ class MoTextProperties(bpy.types.PropertyGroup):
     
     @classmethod
     def clear_other_input(cls, self, context):
-        # Optional: When switching input_type, clear the irrelevant field
-        # For instance, if switching to 'TEXT', you might want to clear 'object_input'
-        # This requires careful handling if you want to preserve previous selections
-        pass
+        if self.input_type == 'TEXT':
+            self.object_input = None
+        elif self.input_type == 'OBJECT':
+            self.text_input = ""
 
 
 # --- Registration ---
 
 # TODO (Inside __init__.py)
 # ... other imports ...
-#from .utils import on_blend_file_changed # Import the handler
+from .utils import on_blend_file_changed # Import the handler
 
 # ... inside register() ...
-    #bpy.app.handlers.load_post.append(on_blend_file_changed)
-    #bpy.app.handlers.save_post.append(on_blend_file_changed)
+    #bpy.app.handlers.load_post.append(utils.on_blend_file_changed)  # Corrected reference
+    #bpy.app.handlers.save_post.append(utils.on_blend_file_changed)  # Corrected reference
     #update_template_list_on_load() # Initial scan
 
 # ... inside unregister() ...
-    #if on_blend_file_changed in bpy.app.handlers.load_post:
-    #    bpy.app.handlers.load_post.remove(on_blend_file_changed)
-    #if on_blend_file_changed in bpy.app.handlers.save_post:
-    #    bpy.app.handlers.save_post.remove(on_blend_file_changed)
+    #if utils.on_blend_file_changed in bpy.app.handlers.load_post:  # Corrected reference
+    #    bpy.app.handlers.load_post.remove(utils.on_blend_file_changed) # Corrected reference
+    #if utils.on_blend_file_changed in bpy.app.handlers.save_post:  # Corrected reference
+    #    bpy.app.handlers.save_post.remove(utils.on_blend_file_changed) # Corrected reference
 
-#classes_to_register = (
-    #MoTextProperties,
-    #ui.MoTextPanel,
-    #operators.MOTEXT_OT_apply_template,
+classes_to_register = (
+    MoTextProperties,
+    ui.MoTextPanel,
+    operators.MOTEXT_OT_apply_template,
+    operators.MOTEXT_OT_refresh_templates, # Added refresh operator
     # Add other classes if you create more
-#)
+)
 
 def register():
+    bpy.app.handlers.load_post.append(utils.on_blend_file_changed)
+    bpy.app.handlers.save_post.append(utils.on_blend_file_changed)
     for cls in classes_to_register:
         bpy.utils.register_class(cls)
     
     # Store properties in the scene (could also be addon preferences)
     bpy.types.Scene.motext_props = bpy.props.PointerProperty(type=MoTextProperties)
     
-    # Refresh template list on registration (and potentially on file load)
-    utils.update_template_list_on_load()
+    # Template list will be populated by handlers or manual refresh.
 
 
 def unregister():
+    if utils.on_blend_file_changed in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.remove(utils.on_blend_file_changed)
+    if utils.on_blend_file_changed in bpy.app.handlers.save_post:
+        bpy.app.handlers.save_post.remove(utils.on_blend_file_changed)
+        
     del bpy.types.Scene.motext_props
     
     for cls in reversed(classes_to_register):

--- a/MoText_addon/operators.py
+++ b/MoText_addon/operators.py
@@ -2,14 +2,38 @@
 import bpy
 import os
 
-# --- Convention for Node Groups in Template Files ---
-# It's CRUCIAL that your mograph_*.blend files have a Geometry Node group
-# with a consistent name that this addon can target.
-TARGET_NODE_GROUP_NAME = "MoTextNodeTool" # e.g., the main GN group in your templates
+# --- Conventions for MoText Template Files ---
+# These constants define the specific naming conventions that users MUST follow
+# when creating their .blend files to be used as templates by the MoText addon.
+# Adherence to these conventions is CRUCIAL for the addon to correctly identify
+# and utilize the Geometry Node setups within the template files.
 
-# Also, this node group needs specific input names the addon can set:
-TEXT_INPUT_SOCKET_NAME = "Input Text"       # For string input
-OBJECT_INPUT_SOCKET_NAME = "Input Object" # For geometry/object input
+# TARGET_NODE_GROUP_NAME:
+#   - Purpose: Specifies the exact name of the Geometry Node group that the MoText
+#     addon will look for and apply from the template .blend file.
+#   - Convention: Template creators MUST name their main Geometry Node group
+#     (intended for use by MoText) exactly as defined by this constant.
+#   - Example: "MoTextNodeTool"
+TARGET_NODE_GROUP_NAME = "MoTextNodeTool"
+
+# TEXT_INPUT_SOCKET_NAME:
+#   - Purpose: Defines the name of the input socket within the TARGET_NODE_GROUP_NAME
+#     that the addon will use to pass text data (if the user selects 'Text' input type).
+#   - Convention: If a template is designed to work with text input, its
+#     TARGET_NODE_GROUP_NAME must have an input socket with this exact name.
+#     This socket should typically be of type String.
+#   - Example: "Input Text"
+TEXT_INPUT_SOCKET_NAME = "Input Text"
+
+# OBJECT_INPUT_SOCKET_NAME:
+#   - Purpose: Defines the name of the input socket within the TARGET_NODE_GROUP_NAME
+#     that the addon will use to pass an existing Blender object (if the user
+#     selects 'Object' input type).
+#   - Convention: If a template is designed to work with an existing object as input,
+#     its TARGET_NODE_GROUP_NAME must have an input socket with this exact name.
+#     This socket should typically be of type Object or Geometry.
+#   - Example: "Input Object"
+OBJECT_INPUT_SOCKET_NAME = "Input Object"
 
 
 class MOTEXT_OT_apply_template(bpy.types.Operator):
@@ -69,36 +93,44 @@ class MOTEXT_OT_apply_template(bpy.types.Operator):
         gn_modifier = target_object.modifiers.new(name="MoTextEffect", type='NODES')
         gn_modifier.node_group = appended_node_group
 
-        # 4. Set inputs on the Geometry Nodes modifier
-        # This relies on the convention that your template node groups have specific input names.
+        # 4. Set inputs on the Geometry Nodes modifier.
+        # This section relies HEAVILY on the naming conventions defined at the top of this file:
+        # TARGET_NODE_GROUP_NAME: The name of the Geometry Node group within your .blend template.
+        # TEXT_INPUT_SOCKET_NAME: The name of the input socket for text data in that node group.
+        # OBJECT_INPUT_SOCKET_NAME: The name of the input socket for object data in that node group.
         
-        # Check if inputs exist before trying to set them
+        # Get the inputs from the instanced node group on the modifier.
         node_inputs = gn_modifier.node_group.inputs
 
         if motext_props.input_type == 'TEXT':
+            # Check if the conventional text input socket name exists in the node group.
             if TEXT_INPUT_SOCKET_NAME in node_inputs:
-                # For Blender 3.x, direct assignment might work if input type is string
-                # For some versions/types, you might need to assign to the default_value of the socket
-                # on the node_group itself before assigning the group, or ensure type matching.
-                # This is often the trickiest part with GN via Python.
                 try:
-                    # Blender 3.3+ way:
+                    # Assign the user's text to the specified input socket.
+                    # Blender's Python API for Geometry Nodes allows direct assignment
+                    # to modifier inputs by their socket name (for Blender 3.3+).
                     gn_modifier[TEXT_INPUT_SOCKET_NAME] = motext_props.text_input
-                    self.report({'INFO'}, f"Set text input to: '{motext_props.text_input}'")
+                    self.report({'INFO'}, f"Set text input '{TEXT_INPUT_SOCKET_NAME}' to: '{motext_props.text_input}'")
                 except Exception as e:
-                    self.report({'WARNING'}, f"Could not set text input '{TEXT_INPUT_SOCKET_NAME}': {e}. Check node group input type.")
+                    # Report error if assignment fails (e.g., type mismatch if the socket isn't a string input).
+                    self.report({'WARNING'}, f"Could not set text input socket '{TEXT_INPUT_SOCKET_NAME}': {e}. Verify the socket type in the node group.")
             else:
-                self.report({'WARNING'}, f"Node group missing text input: '{TEXT_INPUT_SOCKET_NAME}'")
+                # Report warning if the conventional text input socket is not found.
+                self.report({'WARNING'}, f"Node group '{appended_node_group.name}' does not have the expected text input socket: '{TEXT_INPUT_SOCKET_NAME}'.")
         
         elif motext_props.input_type == 'OBJECT':
+            # Check if the conventional object input socket name exists in the node group.
             if OBJECT_INPUT_SOCKET_NAME in node_inputs:
                 try:
+                    # Assign the user's selected object to the specified input socket.
                     gn_modifier[OBJECT_INPUT_SOCKET_NAME] = motext_props.object_input
-                    self.report({'INFO'}, f"Set object input to: '{motext_props.object_input.name}'")
+                    self.report({'INFO'}, f"Set object input '{OBJECT_INPUT_SOCKET_NAME}' to: '{motext_props.object_input.name}'")
                 except Exception as e:
-                    self.report({'WARNING'}, f"Could not set object input '{OBJECT_INPUT_SOCKET_NAME}': {e}. Check node group input type.")
+                    # Report error if assignment fails (e.g., type mismatch if the socket isn't an object/geometry input).
+                    self.report({'WARNING'}, f"Could not set object input socket '{OBJECT_INPUT_SOCKET_NAME}': {e}. Verify the socket type in the node group.")
             else:
-                self.report({'WARNING'}, f"Node group missing object input: '{OBJECT_INPUT_SOCKET_NAME}'")
+                # Report warning if the conventional object input socket is not found.
+                self.report({'WARNING'}, f"Node group '{appended_node_group.name}' does not have the expected object input socket: '{OBJECT_INPUT_SOCKET_NAME}'.")
         
         self.report({'INFO'}, f"MoText applied using template: {os.path.basename(template_blend_path)}")
         return {'FINISHED'}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,74 @@
-# MoText
-A Blender 3D addon which manages Node Tool (.blend files) as templates (presets) for displaying text as motion graphics. Just enter some text on the n-panel, and pick a preset. Now your project has a cool node tree soing something cool with your text.
+# MoText Blender Addon
+
+MoText is a Blender addon designed to simplify the application of pre-configured Geometry Node setups (templates) to text objects or existing scene objects. It allows users to quickly create interesting motion graphics and object effects by selecting a template from a list.
+
+## Features
+
+*   Apply complex Geometry Node effects with a few clicks.
+*   Supports text input directly within the addon panel.
+*   Supports using existing scene objects as input for Geometry Node effects.
+*   Dynamically scans a designated directory for compatible `.blend` templates.
+*   Easy-to-use interface in the 3D View's N-Panel.
+*   Refresh button to update the list of available templates.
+
+## Installation
+
+1.  Download the `MoText_addon` folder (or the entire repository as a ZIP and extract it).
+2.  In Blender, go to `Edit > Preferences > Add-ons`.
+3.  Click `Install...` and navigate to the directory where you saved the `MoText_addon` folder.
+4.  Select the `MoText_addon` folder (or `__init__.py` within it if Blender requires a specific file). If you downloaded a ZIP, you might be able to install it directly.
+5.  Enable the "Object: MoText" addon by checking the box next to its name.
+
+The MoText panel will then be available in the 3D View Sidebar (press 'N' to open) under the "MoText" tab.
+
+## Usage
+
+1.  Open the 3D View Sidebar (N-Panel) and select the "MoText" tab.
+2.  **Choose Input Type**:
+    *   **Text**: Select this to generate an effect based on new text.
+        *   **Text**: Enter the desired text in the input field.
+    *   **Object**: Select this to apply an effect to an existing object.
+        *   **Source Object**: Pick an object from your scene using the eyedropper or dropdown.
+3.  **Select Template**:
+    *   Choose a template from the "Template" dropdown menu. Templates are `.blend` files prefixed with `mograph_` located in the same directory as your currently saved Blender project file.
+    *   If you add new templates to the directory while Blender is open, click the "Refresh Templates" button to update the list.
+4.  **Apply Template**:
+    *   Click the "Apply MoText Template" button.
+    *   This will create a new Empty object named "MoText\_Output" (or similar) at the 3D cursor's location. This object will have a Geometry Nodes modifier containing the setup from the selected template, applied to your chosen text or object.
+
+## Creating MoText Templates
+
+To create your own `.blend` files that are compatible with the MoText addon, follow these requirements:
+
+1.  **File Format**: Templates must be standard Blender `.blend` files.
+2.  **Filename Prefix**: Template filenames **must** be prefixed with `mograph_`. For example, `mograph_my_cool_effect.blend`.
+3.  **Location**: Template files **must** be placed in the same directory as your active (saved) main Blender project file. The addon scans this directory for templates.
+4.  **Target Node Group**:
+    *   Each template `.blend` file **must** contain a Geometry Node group named exactly `MoTextNodeTool`. This is the specific node group the addon will append and use.
+5.  **Input Sockets in "MoTextNodeTool"**:
+    *   The `MoTextNodeTool` group must have appropriately named input sockets for the addon to connect to, based on what your template is designed to process:
+        *   For **Text Input**: If your template processes text, it needs an input socket named exactly `Input Text`. This socket should ideally be of type `String` in your Geometry Node group interface.
+        *   For **Object Input**: If your template processes an existing Blender object, it needs an input socket named exactly `Input Object`. This socket should ideally be of type `Object` or `Geometry` in your Geometry Node group interface.
+    *   Your node group can have other inputs, but these specific names are used by the addon to pass the primary data.
+6.  **Scene Elements (Lighting, Camera)**:
+    *   The MoText addon primarily focuses on applying the Geometry Node setup from the `MoTextNodeTool` group to a target object.
+    *   If your template effect is intended to be a self-contained scene with specific lighting and camera setups, you should include these elements within the template `.blend` file. They can be part of the `MoTextNodeTool` (if appropriate for your node setup) or as separate objects in the template file that users would manually append or link if needed. The addon itself does not automatically handle scene-level elements beyond the Geometry Nodes modifier.
+
+**Example Workflow for a Text Template:**
+
+1.  Create a new `.blend` file.
+2.  Go to the Geometry Nodes workspace.
+3.  Create a new Geometry Node setup on any object (e.g., the default Cube).
+4.  Design your node tree. Ensure it has an input socket for text (e.g., a "String" input node connected to a "String to Curves" node).
+5.  In the "Group" tab of the Geometry Nodes editor (N-panel), name this input socket `Input Text`.
+6.  Name the entire Geometry Node group `MoTextNodeTool`.
+7.  Save the `.blend` file as `mograph_my_text_effect.blend` in the same directory as the project you'll be using the addon with.
+
+## Author
+
+Terence Kearns (with AI assistance)
+
+## License
+
+This project is licensed under the MIT License. (Assuming, if a LICENSE file exists, refer to it. If not, this is a common choice for open-source Blender addons.)
+Consider adding a `LICENSE` file to the repository if one does not exist.


### PR DESCRIPTION
This commit addresses several issues encountered during addon registration and improves overall robustness, particularly concerning filepath access.

Key changes:
- Resolved `RuntimeError: Error: 'list' object is not callable` by ensuring Blender handlers were registered only once via `__init__.py` and removing decorator-based registration in `utils.py`.
- Fixed `'_RestrictData' object has no attribute 'filepath'` errors by:
    - Deferring the initial template list scan from `register()`.
    - Modifying `utils.get_template_files_enum_items` to not call `update_template_list_on_load()` directly, preventing premature `bpy.data.filepath` access.
    - Implementing a new `get_blend_filepath()` function in `utils.py` that safely accesses `bpy.data.filepath` with checks for attribute existence and try-except blocks.
    - Updating `utils.get_project_directory()` to use the new safe `get_blend_filepath()`.
- Ensured `MoTextProperties.clear_other_input` correctly clears the alternative input field.
- Improved comments and `README.md` for your guidance on template creation and addon usage.

The addon should now enable reliably and handle template discovery more robustly.